### PR TITLE
main/postmarketos-base-ui: run SDL in Wayland mode by default

### DIFF
--- a/main/postmarketos-base-ui/APKBUILD
+++ b/main/postmarketos-base-ui/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Clayton Craft <clayton@craftyguy.net>
 pkgname=postmarketos-base-ui
-pkgver=4
-pkgrel=1
+pkgver=5
+pkgrel=0
 pkgdesc="Meta package for minimal postmarketOS UI base"
 url="https://postmarketos.org"
 arch="noarch"
@@ -47,6 +47,7 @@ _source644="
 	"
 _source755="
 	etc/tinydm.d/env-wayland.d/50-firefox-wayland.sh
+	etc/tinydm.d/env-wayland.d/50-sdl-wayland.sh
 	"
 
 # Avoid filename based checksum conflicts by including the whole path.
@@ -98,6 +99,7 @@ tinydm() {
 	provides="postmarketos-base-tinydm=$pkgver-r$pkgrel"
 	amove etc/conf.d/tinydm
 	amove etc/tinydm.d/env-wayland.d/50-firefox-wayland.sh
+	amove etc/tinydm.d/env-wayland.d/50-sdl-wayland.sh
 }
 
 pulseaudio() {
@@ -130,4 +132,5 @@ fe0651904c1f40ffa67d83daca190af199f63247e53642a59a1e1147cd06776fcf20b7b2fcc53737
 90b30cbea660ef6cd4c0461b6935de0cd63a84a1a40edb24348a83044c97935b974bd8bafda9cd558e92d3eb69e22c5ccf55483b80f839e24f0eb57ae2df6fe3  rootfs-etc-skel-.profile
 6b9c7bb73213187eb9ca8a94109b2b816f50c1158c90fec2e92b373864280d67741589e5bfbab8810945f031d2f4b535aad78a72e46e52ea50be5b85324da381  rootfs-etc-sleep-inhibitor.conf
 d1ddd43489e6016e3ffd716027ed2bae4a2ab5f213118bdbcb96750e267ab7c0367cd0e0e386300aa5550352653144f5caeddd790621fe0879f83ca1995bb65c  rootfs-etc-tinydm.d-env-wayland.d-50-firefox-wayland.sh
+ecaa57d033a119a53a6574c27636b7c89d659d75ea48a973a6a4ff6f90e5d07202529fd489bfc9dfc7430f5b60f40612f6d5c06f7fab47e681b0a3112a874058  rootfs-etc-tinydm.d-env-wayland.d-50-sdl-wayland.sh
 "

--- a/main/postmarketos-base-ui/rootfs-etc-tinydm.d-env-wayland.d-50-sdl-wayland.sh
+++ b/main/postmarketos-base-ui/rootfs-etc-tinydm.d-env-wayland.d-50-sdl-wayland.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+export SDL_VIDEODRIVER=wayland


### PR DESCRIPTION
This is possible now that all SDL (1) applications use sdl12-compat
instead of "classic" SDL 1.2. Note that this only is applied to user
interfaces that use Wayland and are launched through tinydm.

See https://gitlab.alpinelinux.org/alpine/aports/-/issues/12739