### PR TITLE
treewide: remove *-openrc depends (MR 1800)

### DIFF
--- a/device/testing/device-oneplus-oneplus3/APKBUILD
+++ b/device/testing/device-oneplus-oneplus3/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=device-oneplus-oneplus3
 pkgdesc="OnePlus 3"
 pkgver=1
-pkgrel=4
+pkgrel=5
 url="https://postmarketos.org"
 license="MIT"
 arch="aarch64"
@@ -34,7 +34,6 @@ nonfree_firmware() {
 		firmware-oneplus-oneplus3-op3
 		msm-modem-rpmsg
 		qrtr
-		qrtr-openrc
 		"
 	install="$subpkgname.post-install"
 	mkdir "$subpkgdir"

--- a/device/testing/device-oneplus-oneplus3t/APKBUILD
+++ b/device/testing/device-oneplus-oneplus3t/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=device-oneplus-oneplus3t
 pkgdesc="OnePlus 3T"
 pkgver=1
-pkgrel=4
+pkgrel=5
 url="https://postmarketos.org"
 license="MIT"
 arch="aarch64"
@@ -34,7 +34,6 @@ nonfree_firmware() {
 		firmware-oneplus-oneplus3-op3t
 		msm-modem-rpmsg
 		qrtr
-		qrtr-openrc
 		"
 	install="$subpkgname.post-install"
 	mkdir "$subpkgdir"

--- a/device/testing/soc-qcom-sdm845/APKBUILD
+++ b/device/testing/soc-qcom-sdm845/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=soc-qcom-sdm845
 pkgdesc="Common package for Qualcomm SDM845 devices"
 pkgver=1
-pkgrel=1
+pkgrel=2
 url="https://postmarketos.org"
 license="BSD-3-Clause"
 arch="aarch64"
@@ -16,7 +16,7 @@ package() {
 
 nonfree_firmware() {
 	pkgdesc="Modem, WiFi and GPU Firmware"
-	depends="pd-mapper pd-mapper-openrc tqftpserv tqftpserv-openrc msm-modem"
+	depends="pd-mapper tqftpserv tqftpserv-openrc msm-modem"
 	install="$subpkgname.post-install"
 	mkdir "$subpkgdir"
 }

--- a/main/postmarketos-ui-i3wm/APKBUILD
+++ b/main/postmarketos-ui-i3wm/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Martijn Braam <martijn@brixit.nl>
 pkgname=postmarketos-ui-i3wm
 pkgver=0.3
-pkgrel=6
+pkgrel=7
 pkgdesc="(X11) Tiling WM (keyboard required)"
 url="https://i3wm.org"
 arch="noarch"
 license="GPL-3.0-or-later"
-depends="xorg-server mesa-egl i3wm i3status dmenu xset xinput st lightdm lightdm-openrc elogind"
+depends="xorg-server mesa-egl i3wm i3status dmenu xset xinput st lightdm elogind"
 install="$pkgname.post-install $pkgname.pre-deinstall $pkgname.post-deinstall $pkgname.post-upgrade"
 source="lock.sh 65-lightdm-autologin.conf"
 options="!check"

--- a/main/postmarketos-ui-kodi/APKBUILD
+++ b/main/postmarketos-ui-kodi/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=postmarketos-ui-kodi
 pkgver=1
-pkgrel=4
+pkgrel=5
 pkgdesc="(Wayland) 10-foot UI useful on TV's"
 url="https://kodi.tv"
 arch="noarch !armhf !x86" # x86: aports#11807
 license="GPL-3.0-or-later"
-depends="kodi-wayland kodi cage lightdm lightdm-openrc elogind pulseaudio upower"
+depends="kodi-wayland kodi cage lightdm elogind pulseaudio upower"
 install="$pkgname.post-install $pkgname.post-upgrade"
 source="63-lightdm-autologin.conf kodi.desktop"
 options="!check"

--- a/main/postmarketos-ui-mate/APKBUILD
+++ b/main/postmarketos-ui-mate/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Daniele Debernardi <drebrez@gmail.com>
 pkgname=postmarketos-ui-mate
 pkgver=1
-pkgrel=11
+pkgrel=12
 pkgdesc="(X11) MATE Desktop Environment, fork of GNOME2 (stylus recommended)"
 url="http://mate-desktop.org/"
 arch="noarch"
 license="GPL-3.0-or-later"
-depends="mate-desktop-environment xorg-server dbus-x11 mesa-egl postmarketos-artwork-wallpapers gtk+2.0 lightdm lightdm-openrc"
+depends="mate-desktop-environment xorg-server dbus-x11 mesa-egl postmarketos-artwork-wallpapers gtk+2.0 lightdm"
 install="$pkgname.post-install $pkgname.pre-deinstall $pkgname.post-deinstall $pkgname.post-upgrade"
 source="000-system-background.gschema.override 001-screensaver.gschema.override 61-lightdm-autologin.conf"
 options="!check"

--- a/main/postmarketos-ui-phosh/APKBUILD
+++ b/main/postmarketos-ui-phosh/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=postmarketos-ui-phosh
 pkgver=6
-pkgrel=2
+pkgrel=3
 pkgdesc="(Wayland) Mobile UI developed for the Librem 5 (works only with numeric passwords!)"
 url="https://puri.sm"
 arch="noarch !armhf !x86" # x86: aports#11807
@@ -9,7 +9,6 @@ license="GPL-3.0-or-later"
 depends="bluez
 	gnome-keyring
 	iio-sensor-proxy
-	iio-sensor-proxy-openrc
 	phosh
 	polkit-elogind
 	pulseaudio

--- a/main/postmarketos-ui-plasma-mobile/APKBUILD
+++ b/main/postmarketos-ui-plasma-mobile/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=postmarketos-ui-plasma-mobile
 pkgver=3.1
-pkgrel=2
+pkgrel=3
 pkgdesc="(Wayland) Mobile variant of KDE Plasma (does not run without hardware acceleration, allows only numeric passwords!)"
 url="https://wiki.postmarketos.org/wiki/Plasma_Mobile"
 arch="noarch !armhf !x86" # armhf: pmaports#75, x86: aports#11807
@@ -10,12 +10,10 @@ depends="bluedevil
 	breeze
 	elogind
 	iio-sensor-proxy
-	iio-sensor-proxy-openrc
 	kscreen
 	kwallet-pam
 	kwayland-integration
 	ofono
-	ofono-openrc
 	plasma-phone-components
 	plasma-nm-mobile
 	polkit-kde-agent-1
@@ -24,7 +22,6 @@ depends="bluedevil
 	qt5-qtvirtualkeyboard
 	xdg-desktop-portal-kde
 	urfkill
-	urfkill-openrc
 	"
 # Required to launch
 depends="$depends

--- a/main/postmarketos-ui-sway/APKBUILD
+++ b/main/postmarketos-ui-sway/APKBUILD
@@ -1,14 +1,13 @@
 # Maintainer: Danct12 <danct12@disroot.org>
 pkgname=postmarketos-ui-sway
 pkgver=2
-pkgrel=1
+pkgrel=2
 pkgdesc="(Wayland) Tiling WM, drop-in replacement for i3wm (DOES NOT RUN WITHOUT HW ACCELERATION!)"
 url="https://postmarketos.org"
 arch="noarch !armhf !x86" # armhf,x86: aports#11807
 license="GPL-3.0-or-later"
 depends="elogind
 	lightdm
-	lightdm-openrc
 	sway
 	"
 _pmb_recommends="alacritty

--- a/main/postmarketos-ui-weston/APKBUILD
+++ b/main/postmarketos-ui-weston/APKBUILD
@@ -1,14 +1,13 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=postmarketos-ui-weston
 pkgver=5
-pkgrel=0
+pkgrel=1
 pkgdesc="(Wayland) Reference compositor (demo, not a phone interface)"
 url="https://postmarketos.org"
 arch="noarch"
 license="GPL-3.0-or-later"
 depends="elogind
 	lightdm
-	lightdm-openrc
 	weston-clients
 	weston
 	weston-shell-desktop

--- a/main/postmarketos-ui-xfce4/APKBUILD
+++ b/main/postmarketos-ui-xfce4/APKBUILD
@@ -1,14 +1,13 @@
 # Maintainer: Daniele Debernardi <drebrez@gmail.com>
 pkgname=postmarketos-ui-xfce4
 pkgver=0.3
-pkgrel=4
+pkgrel=5
 pkgdesc="(X11) Lightweight desktop (stylus recommended)"
 url="https://gitlab.com/postmarketOS/xfce4-phone"
 arch="noarch"
 license="GPL-3.0-or-later"
 depends="elogind
 	lightdm
-	lightdm-openrc
 	lxpolkit
 	mesa-egl
 	xfce4

--- a/modem/msm-modem/APKBUILD
+++ b/modem/msm-modem/APKBUILD
@@ -1,11 +1,11 @@
 pkgname=msm-modem
 pkgver=3
-pkgrel=0
+pkgrel=1
 pkgdesc="Common support for Qualcomm MSM modems"
 url="https://postmarketos.org/"
 arch="armhf armv7 aarch64"
 license="GPL-3.0-or-later"
-depends="rmtfs rmtfs-openrc"
+depends="rmtfs"
 install="$pkgname.post-install"
 subpackages="$pkgname-rpmsg $pkgname-downstream"
 source="msm-modem-downstream.initd udev-rpmsg.rules udev-downstream.rules"


### PR DESCRIPTION
postmarketos-base depends on alpine-base, which depends on openrc. This
pulls in all *-openrc subpackages when their main packages get
installed, so we don't need to add them as dependency.

See the install_if in abuild.in of default_openrc():
https://gitlab.alpinelinux.org/alpine/abuild/-/blob/10aa67a0cab480c9df2a050e0d102aca0cf18a02/abuild.in#L1943-1946

[ci:ignore-count]