### PR TITLE
temp/xkeyboard-config: upgrade to 2.35.1

### DIFF
--- a/temp/xkeyboard-config/0013-Add-model-for-Pine64-PinePhone-keyboard.patch
+++ b/temp/xkeyboard-config/0013-Add-model-for-Pine64-PinePhone-keyboard.patch
@@ -1,0 +1,76 @@
+From 29caecafe108436ffdc947bd36844f5e3e056d7e Mon Sep 17 00:00:00 2001
+From: undef <gitlab@undef.tools>
+Date: Thu, 14 Apr 2022 08:54:12 +0000
+Subject: [PATCH] Add model for Pine64 PinePhone keyboard
+
+This adds a model for the Pine64 PinePhone Keyboard
+(https://wiki.pine64.org/wiki/PinePhone_(Pro)_Keyboard).
+Specifically, it implements the symbols listed on the top
+row of the keyboard as a third layer which are not
+available in the kernel driver.
+
+Backport by ollieparanoid from:
+https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/322
+---
+ rules/0002-base.lists.part |  2 +-
+ rules/base.xml             |  7 +++++++
+ symbols/inet               | 15 +++++++++++++++
+ 3 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/rules/0002-base.lists.part b/rules/0002-base.lists.part
+index 75059447..8c9eaf82 100644
+--- a/rules/0002-base.lists.part
++++ b/rules/0002-base.lists.part
+@@ -37,7 +37,7 @@
+               sven sven303 symplon \
+               teck227 teck229 \
+               toshiba_s3000 trust trustda \
+-              unitekkb1925 yahoo \
++              unitekkb1925 yahoo ppkb \
+               apex300
+ 
+ ! $inetmediakbds = acer_ferrari4k acer_laptop btc5090 btc9019u cherryblueb \
+diff --git a/rules/base.xml b/rules/base.xml
+index 8bc0447a..ef5fe221 100644
+--- a/rules/base.xml
++++ b/rules/base.xml
+@@ -1333,6 +1333,13 @@
+        <vendor>Google</vendor>
+      </configItem>
+     </model>
++    <model>
++      <configItem>
++       <name>ppkb</name>
++       <description>PinePhone Keyboard</description>
++       <vendor>Pine64</vendor>
++     </configItem>
++    </model>
+   </modelList>
+   <layoutList>
+     <layout>
+diff --git a/symbols/inet b/symbols/inet
+index 518d846e..18fa9eb5 100644
+--- a/symbols/inet
++++ b/symbols/inet
+@@ -2071,3 +2071,18 @@ xkb_symbols "teck229" {
+     include "inet(teck227)"
+ };
+ 
++
++partial alphanumeric_keys
++xkb_symbols "ppkb" {
++
++    key <AE01> {        [         1,    exclam,         bar             ]       };
++    key <AE02> {        [         2,    at,             backslash       ]       };
++    key <AE03> {        [         3,    numbersign,     sterling        ]       };
++    key <AE04> {        [         4,    dollar,         EuroSign        ]       };
++    key <AE05> {        [         5,    percent,        asciitilde      ]       };
++    key <AE06> {        [         6,    asciicircum,    grave           ]       };
++    key <AE07> {        [         7,    ampersand,      minus           ]       };
++    key <AE08> {        [         8,    asterisk,       equal           ]       };
++    key <AE09> {        [         9,    parenleft,      underscore      ]       };
++    key <AE10> {        [         0,    parenright,     plus            ]       };
++};
+-- 
+2.34.1
+

--- a/temp/xkeyboard-config/APKBUILD
+++ b/temp/xkeyboard-config/APKBUILD
@@ -1,15 +1,15 @@
 # Forked from Alpine, so we can extend the keyboard layouts
 pkgname=xkeyboard-config
 pkgver=9999
-_pkgver=2.33
-pkgrel=3
+_pkgver=2.35.1
+pkgrel=4
 pkgdesc="X keyboard configuration files"
 url="http://www.freedesktop.org/wiki/Software/XKeyboardConfig"
 arch="noarch"
 license="MIT"
 subpackages="$pkgname-doc"
 makedepends="meson perl libxslt"
-source="https://www.x.org/archive/individual/data/xkeyboard-config/xkeyboard-config-$_pkgver.tar.bz2
+source="$pkgname-$_pkgver.tar.gz::https://github.com/freedesktop/xkeyboard-config/archive/refs/tags/xkeyboard-config-$_pkgver.tar.gz
 	0001-RX-51-Symbols-Bind-Escape-to-third-level-Backspace.patch
 	0002-RX-51-Symbols-Bind-function-keys-to-fourth-level-top.patch
 	0003-RX-51-Symbols-Bind-PgUp-PgDown-Home-End-to-third-lev.patch
@@ -22,8 +22,9 @@ source="https://www.x.org/archive/individual/data/xkeyboard-config/xkeyboard-con
 	0010-RX-51-Symbols-Bind-braces-to-fourth-level-N-and-M.patch
 	0011-RX-51-Symbols-Extend-Swiss-layout.patch
 	0012-RX-51-Symbols-Bind-square-brackets.patch
+	0013-Add-model-for-Pine64-PinePhone-keyboard.patch
 	"
-builddir="$srcdir/$pkgname-$_pkgver"
+builddir="$srcdir/xkeyboard-config-xkeyboard-config-$_pkgver"
 
 build() {
 	abuild-meson . output
@@ -38,7 +39,7 @@ package() {
 	DESTDIR="$pkgdir" meson install --no-rebuild -C output
 }
 sha512sums="
-084f79350d5dc7f9ebd5b5333d386459b0ab587f6cec27ee2d8d5c3a56b08993f9fafb9d893307f4d43cfeaf2e225c5295ad6297ae8287c68efc48a82638feb1  xkeyboard-config-2.33.tar.bz2
+2016e126dd807c07cdec045089a83b5b8c2e6eac8255a80c4e5976a0defc7ad55144186457a3109765f3bfb775270296d980366fee3826ee0e3bcd957e60aa5b  xkeyboard-config-2.35.1.tar.gz
 6a761968c0101251a256e4a0b9545c953ba82ecf5f20af35a2c487c01dfdb8804caf32eff0b9534854b7adaab5693a937fbb245c2a1001253735a48d90f80824  0001-RX-51-Symbols-Bind-Escape-to-third-level-Backspace.patch
 13950fc4064f55a69adf2f0dc3d9e2f8ec31ad686202486f772745ed9c7a8b502aed6073c5d629eac30a274194f5d29402f64c2f286b4a46807f3bcfab6753ff  0002-RX-51-Symbols-Bind-function-keys-to-fourth-level-top.patch
 db3c4a1f30c2efc3bf5bba7541d6956414f0d09f089d0ad5e35d340fc2c0faf8bdd6eb8c3708db307ad2c9e7ac841de8c4d11ead076d9c65dd5458b292efae19  0003-RX-51-Symbols-Bind-PgUp-PgDown-Home-End-to-third-lev.patch
@@ -51,4 +52,5 @@ fe44b3535ec586a58901e63cb47413b574e19e889d1a2d32fd4c53dc6e374d78caa081f4679d374c
 6241cc409bc4cbe4149d8703ae413c11fc2066c14374cf9fe126066759b4c9a1592ff183d3d14b5ee168be6678a2844cee622a1226ac1ddbc7d9b058143c591b  0010-RX-51-Symbols-Bind-braces-to-fourth-level-N-and-M.patch
 65f92b510db6cb38d3761d4f38368875680b4ded1243c1f54b573d3a44820866892e25dfa3a4e729fe82575144b0d464f11150638b812a0884509fc9c9d5f5d0  0011-RX-51-Symbols-Extend-Swiss-layout.patch
 8dd15fc2877b86265885648b733e12b68be6a7c14aa0ce79cf4649c12ab1445ff3111039651fc4243439ab46352b80a6d1be81c62978c8a22aa4300b8f1b5edd  0012-RX-51-Symbols-Bind-square-brackets.patch
+363ac31d24d419d66be51ea22564864813c9b982779181d804707b1c3ee9507846c5061f6cf006af92faa0c0f17e39f50798baedc7d7d2ed3a69386d13602b39  0013-Add-model-for-Pine64-PinePhone-keyboard.patch
 "


### PR DESCRIPTION
Upgrade to latest version and add a backport of the PinePhone keyboard
patch by Undef, which is already merged to upstream master and therefore
will be in the next version.

Adjust the source URL to the same that is in the Alpine APKBUILD.

Keep the RX-51 (Nokia N900) patches for now, but it would be good if we
could upstream/drop them in order to use Alpine's package again in the
near future. Created pmaports issue 1521 for that.

Related: pmaports issue 1515